### PR TITLE
Break chutes when propsurfing

### DIFF
--- a/lua/cfc_parachutes/shared/sh_parachute.lua
+++ b/lua/cfc_parachutes/shared/sh_parachute.lua
@@ -112,7 +112,7 @@ local function addHorizontalVel( ply, chute, vel, timeMult )
         vel[1] = vel[1] * mult
         vel[2] = vel[2] * mult
         if SERVER then -- so propsurf breaks it
-            chute._chuteHealth = chute._chuteHealth + -1
+            chute:ChuteTakeDamage( 1 )
         end
     end
 

--- a/lua/cfc_parachutes/shared/sh_parachute.lua
+++ b/lua/cfc_parachutes/shared/sh_parachute.lua
@@ -111,6 +111,9 @@ local function addHorizontalVel( ply, chute, vel, timeMult )
 
         vel[1] = vel[1] * mult
         vel[2] = vel[2] * mult
+        if SERVER then -- so propsurf breaks it
+            chute._chuteHealth = chute._chuteHealth + -1
+        end
     end
 
     return vel
@@ -121,13 +124,13 @@ function CFC_Parachute._ApplyChuteForces( ply, chute, mv )
     local vel = mv and mv:GetVelocity() or ply:GetVelocity()
     local velZ = vel[3]
 
-    if velZ > cvFallZVel then return end
-
     local timeMult = FrameTime()
 
     -- Modify velocity.
     vel = addHorizontalVel( ply, chute, vel, timeMult )
     velZ = velZ + ( cvFallZVel - velZ ) * cvFallLerp * timeMult
+
+    if velZ > cvFallZVel then return end -- do this after we check the horizontal vel
 
     vel[3] = velZ
     if mv then

--- a/lua/cfc_parachutes/shared/sh_parachute.lua
+++ b/lua/cfc_parachutes/shared/sh_parachute.lua
@@ -130,7 +130,9 @@ function CFC_Parachute._ApplyChuteForces( ply, chute, mv )
     vel = addHorizontalVel( ply, chute, vel, timeMult )
     velZ = velZ + ( cvFallZVel - velZ ) * cvFallLerp * timeMult
 
-    if velZ > cvFallZVel then return end -- do this after we check the horizontal vel
+    -- do this after we check the horizontal vel
+    -- otherwise players going even remotely upwards with a parachute out won't have their vel limited
+    if velZ > cvFallZVel then return end
 
     vel[3] = velZ
     if mv then

--- a/lua/entities/cfc_parachute/init.lua
+++ b/lua/entities/cfc_parachute/init.lua
@@ -112,6 +112,18 @@ function ENT:Close( expireDelay )
     end )
 end
 
+function ENT:BreakChute()
+    self:Close()
+    self:EmitSound( "physics/cardboard/cardboard_box_impact_bullet1.wav", 75, 100, 1 )
+    self._chuteNextOpen = CurTime() + CHUTE_BROKEN_DELAY
+    self._chuteHealth = CHUTE_MAX_HEALTH
+
+    local owner = self:GetOwner()
+    if not IsValid( owner ) then return end
+
+    owner:ChatPrint( "Your chute broke..." ) -- meh print
+end
+
 function ENT:OnRemove()
     table.RemoveByValue( allParachutes, self )
     timer.Remove( "CFC_Parachute_ExpireChute_" .. self:EntIndex() )
@@ -135,11 +147,7 @@ function ENT:Think()
     end
 
     if self._chuteHealth <= 0 then -- so propsurf breaks it
-        self:Close()
-        owner:ChatPrint( "Your chute broke..." ) -- meh print
-        self:EmitSound( "physics/cardboard/cardboard_box_impact_bullet1.wav", 75, 100, 1 )
-        self._chuteNextOpen = CurTime() + CHUTE_BROKEN_DELAY
-        self._chuteHealth = CHUTE_MAX_HEALTH
+        self:BreakChute()
     end
 
     if owner:WaterLevel() >= 2 then

--- a/lua/entities/cfc_parachute/init.lua
+++ b/lua/entities/cfc_parachute/init.lua
@@ -152,6 +152,11 @@ function ENT:Think()
     return true
 end
 
+function ENT:ChuteTakeDamage( damage )
+    if not self._chuteIsOpen then return end
+    self._chuteHealth = self._chuteHealth - damage
+end
+
 function ENT:CanOpen()
     if self._chuteIsOpen then return false end
 

--- a/lua/entities/cfc_parachute/init.lua
+++ b/lua/entities/cfc_parachute/init.lua
@@ -8,6 +8,8 @@ CFC_Parachute = CFC_Parachute or {}
 local EXPIRATION_DELAY = GetConVar( "cfc_parachute_expiration_delay" )
 local FALL_SPEED = GetConVar( "cfc_parachute_fall_speed" )
 local VIEWPUNCH_STRENGTH = GetConVar( "cfc_parachute_viewpunch_strength" )
+local CHUTE_MAX_HEALTH = 40
+local CHUTE_BROKEN_DELAY = 4
 
 local COLOR_SHOW = Color( 255, 255, 255, 255 )
 local COLOR_HIDE = Color( 255, 255, 255, 0 )
@@ -51,6 +53,8 @@ function ENT:Initialize()
     self._chuteMoveLeft = 0
     self._chuteDirRel = Vector( 0, 0, 0 )
     self._chuteDirRel = Vector( 0, 0, 0 )
+    self._chuteNextOpen = 0
+    self._chuteHealth = CHUTE_MAX_HEALTH
 
     table.insert( allParachutes, self )
 
@@ -75,6 +79,7 @@ function ENT:Open()
     self:ApplyViewPunch()
 
     self._chuteIsOpen = true
+
     self:SetNoDraw( false )
     self:DrawShadow( true )
     self:_UpdateChuteDirection()
@@ -129,6 +134,18 @@ function ENT:Think()
         return
     end
 
+    if self._chuteHealth <= 0 then -- so propsurf breaks it
+        self:Close()
+        owner:ChatPrint( "Your chute broke..." ) -- meh print
+        self:EmitSound( "physics/cardboard/cardboard_box_impact_bullet1.wav", 75, 100, 1 )
+        self._chuteNextOpen = CurTime() + CHUTE_BROKEN_DELAY
+        self._chuteHealth = CHUTE_MAX_HEALTH
+    end
+
+    if owner:WaterLevel() >= 2 then
+        self:Close()
+    end
+
     self:SetAngles( owner:GetAngles() )
     self:NextThink( CurTime() )
 
@@ -138,8 +155,11 @@ end
 function ENT:CanOpen()
     if self._chuteIsOpen then return false end
 
+    if self._chuteNextOpen > CurTime() then return false end
+
     local owner = self:GetOwner()
     if not IsValid( owner ) then return false end
+    if owner:WaterLevel() >= 1 then return false end
     if CFC_Parachute.IsPlayerCloseToGround( owner ) then return false end
 
     return true


### PR DESCRIPTION
add chute health
health is reduced when over the speed limit
eventually breaks chute, puts it on a short cooldown

also close chute when owner is in water

also do speed clamping even if player's z velocity is positive